### PR TITLE
chore: Reduce artifact retention to 1 day

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -190,7 +190,7 @@ jobs:
         with:
           name: e2e-screenshot
           path: e2e-screenshot.png
-          retention-days: 7
+          retention-days: 1
           
       - name: Clean up
         if: always()


### PR DESCRIPTION
## Summary
- Updates artifact retention period from 7/90 days to 1 day
- Reduces GitHub Actions artifact storage costs

## Changes
- Modified `.github/workflows/e2e.yml` to set `retention-days: 1` for `actions/upload-artifact@v4`

## Rationale
This change helps optimize GitHub Actions storage costs by reducing artifact retention to 1 day, which is sufficient for debugging recent workflow runs while preventing unnecessary long-term storage of build artifacts.